### PR TITLE
feat : 장바구니 기능

### DIFF
--- a/HotSource/src/main/java/hotsource/controller/main/CartController.java
+++ b/HotSource/src/main/java/hotsource/controller/main/CartController.java
@@ -1,0 +1,87 @@
+package hotsource.controller.main;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.servlet.http.HttpSession;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.servlet.ModelAndView;
+
+import hotsource.domain.AssetImg;
+import hotsource.domain.Cart;
+import hotsource.domain.User;
+import hotsource.exception.CartException;
+import hotsource.model.asset.AssetService;
+import hotsource.model.cart.CartService;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Controller
+public class CartController {
+	
+	@Autowired
+	private CartService cartService;
+	
+	@Autowired 
+	private AssetService assetService;
+
+	@GetMapping("/cart")
+	public ModelAndView getCart(HttpSession session) {
+		ModelAndView mav = new ModelAndView("main/cart/list");
+		User loginUser = (User)session.getAttribute("user");
+		log.debug("login id=" + loginUser.getUser_id());
+		
+		List<Cart> carts = cartService.getCartList(loginUser.getUser_id());   // 수정 필요: 로그인 유저 id
+		
+		List<Integer> discountList = new ArrayList<>();
+		List<AssetImg> thumbnailList = new ArrayList<>();
+		
+		
+		for(int i = 0; i < carts.size(); i++) {
+			discountList.add(assetService.getDiscountPrice(carts.get(i).getAsset()));
+			thumbnailList.add(assetService.getThumbnail(carts.get(i).getAsset().getAsset_id()));
+			log.debug("썸네일 이미지 파일명=" + thumbnailList.get(i).getAsset_img_url());
+		}
+		log.debug("썸네일개수="+thumbnailList.size());
+		
+		mav.addObject("cartList", carts);
+		mav.addObject("discountList", discountList);
+		mav.addObject("thumbnailList", thumbnailList);
+		
+		return mav;
+	}
+	
+	
+	@PostMapping("/cart/delete")
+	@ResponseBody
+	public String removeCartItem(int cart_id) {
+		try {
+			cartService.delete(cart_id);
+		} catch (CartException e) {
+			
+			e.printStackTrace();
+		}
+		
+		return "ok";
+	}
+	
+	@PostMapping("/cart/deleteSelected")
+	@ResponseBody
+	public String removeMultipleCartItem(@RequestParam("cart_ids") List<Long> cart_ids) {
+		try {
+			cartService.deleteSelected(cart_ids);
+		} catch (CartException e) {
+			e.printStackTrace();
+		}
+		
+		return "ok";
+	}
+	
+}
+

--- a/HotSource/src/main/java/hotsource/domain/Asset.java
+++ b/HotSource/src/main/java/hotsource/domain/Asset.java
@@ -16,9 +16,11 @@ public class Asset {
 	private Timestamp create_date;
 	private int view_count;	
 	
+	private Sale sale; // 유효한 세일, null인 경우 적용 가능한 sale이 없는 것임
     private Seller seller;
     private SubCategory subCategory;
-       
+    
+    
 	private List<Review> reviewList;
 	private List<AssetKeywordMapping> keywordList;
 	private List<AssetFile> fileList;

--- a/HotSource/src/main/java/hotsource/domain/Sale.java
+++ b/HotSource/src/main/java/hotsource/domain/Sale.java
@@ -7,11 +7,8 @@ import lombok.Data;
 @Data
 public class Sale {
 	private long sale_id;
-	private String sale_type;
 	private int sale_value;
 	private Timestamp start_date;
 	private Timestamp end_date;
 	private Timestamp create_date;
-	
-	private Asset asset;
 }

--- a/HotSource/src/main/java/hotsource/domain/Wishlist.java
+++ b/HotSource/src/main/java/hotsource/domain/Wishlist.java
@@ -2,6 +2,7 @@
 package hotsource.domain;
 
 import java.sql.Timestamp;
+import java.util.List;
 
 import lombok.Data;
 
@@ -11,6 +12,6 @@ public class Wishlist {
 	private String list_name;
 	private String description;
 	private Timestamp create_date;
-	
 	private User user;
+	private List<WishlistItem>  itemList; 
 }

--- a/HotSource/src/main/java/hotsource/exception/AssetImgException.java
+++ b/HotSource/src/main/java/hotsource/exception/AssetImgException.java
@@ -1,0 +1,14 @@
+package hotsource.exception;
+
+public class AssetImgException extends RuntimeException{
+
+	public AssetImgException(String msg) {
+		super(msg);
+	}
+	public AssetImgException(String msg, Throwable e) {
+		super(msg, e);
+	}
+	public AssetImgException(Throwable e) {
+		super(e);
+	}
+}

--- a/HotSource/src/main/java/hotsource/model/asset/AssetService.java
+++ b/HotSource/src/main/java/hotsource/model/asset/AssetService.java
@@ -3,6 +3,7 @@ package hotsource.model.asset;
 import java.util.List;
 
 import hotsource.domain.Asset;
+import hotsource.domain.AssetImg;
 
 public interface AssetService {
 	public List selectAll();
@@ -13,4 +14,8 @@ public interface AssetService {
 	public void regist(Asset asset);
 	public void update(Asset asset);
 	public void delete(long asset_id);
+	
+	//할인 적용된 가격 구하기 (10000원에서 20%할인해서 최종 가격 : 8000원 반환)
+	public int getDiscountPrice(Asset asset); 
+	public AssetImg getThumbnail(long asset_id);
 }

--- a/HotSource/src/main/java/hotsource/model/asset/AssetServiceImpl.java
+++ b/HotSource/src/main/java/hotsource/model/asset/AssetServiceImpl.java
@@ -6,12 +6,22 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import hotsource.domain.Asset;
+import hotsource.domain.AssetImg;
+import hotsource.domain.Sale;
+import hotsource.model.asset_img.AssetImgDAO;
+import hotsource.model.sale.SaleService;
 
 @Service
 public class AssetServiceImpl implements AssetService {
 	
 	@Autowired
 	private AssetDAO assetDAO;
+	
+	@Autowired
+	private AssetImgDAO assetImgDAO;
+	
+	@Autowired 
+	private SaleService saleService;
 	
 	@Override
 	public List selectAll() {
@@ -46,4 +56,23 @@ public class AssetServiceImpl implements AssetService {
 	public void delete(long asset_id) {
 		
 	}
+
+	@Override
+	public int getDiscountPrice(Asset asset) {
+		Sale sale = saleService.selectByAssetId(asset.getAsset_id());
+		
+		if(sale == null) {
+			return 0;
+		}else {
+			return asset.getPrice() -(asset.getPrice() * sale.getSale_value() / 100); 
+		}
+	}
+
+	@Override
+	public AssetImg getThumbnail(long asset_id) {
+		return assetImgDAO.selectThumbnailByAssetId(asset_id);
+	}
+	
+	
+	
 }

--- a/HotSource/src/main/java/hotsource/model/asset_img/AssetImgDAO.java
+++ b/HotSource/src/main/java/hotsource/model/asset_img/AssetImgDAO.java
@@ -1,0 +1,18 @@
+package hotsource.model.asset_img;
+
+import java.util.List;
+
+import hotsource.domain.AssetImg;
+
+public interface AssetImgDAO {
+	
+	public AssetImg select(long asset_img_id);
+	public List<AssetImg> selectByAssetId(long asset_img_id);
+	public AssetImg selectThumbnailByAssetId(long asset_id);
+	
+	public void insert(AssetImg assetImg);
+	public void update(AssetImg assetImg);
+	public void delete(long asset_img_id);
+	public void deleteByAssetId(long asset_id);
+
+}

--- a/HotSource/src/main/java/hotsource/model/asset_img/MybatisAssetImgDAO.java
+++ b/HotSource/src/main/java/hotsource/model/asset_img/MybatisAssetImgDAO.java
@@ -1,0 +1,67 @@
+package hotsource.model.asset_img;
+
+import java.util.List;
+
+import org.mybatis.spring.SqlSessionTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+import hotsource.domain.AssetImg;
+import hotsource.exception.AssetImgException;
+
+@Repository
+public class MybatisAssetImgDAO implements AssetImgDAO{
+
+	@Autowired
+	private SqlSessionTemplate sqlSessionTemplate;
+	
+	@Override
+	public AssetImg select(long asset_img_id) {
+		return sqlSessionTemplate.selectOne("AssetImg.select", asset_img_id);
+	}
+
+	@Override
+	public List<AssetImg> selectByAssetId(long asset_id) {
+		return sqlSessionTemplate.selectList("AssetImg.selectByAssetId", asset_id);
+	}
+
+	@Override
+	public AssetImg selectThumbnailByAssetId(long asset_id) {
+		return sqlSessionTemplate.selectOne("AssetImg.selectThumbnailByAssetId", asset_id);
+	}
+
+	@Override
+	public void insert(AssetImg assetImg) throws AssetImgException{
+		int result = sqlSessionTemplate.insert("AssetImg.insert", assetImg);
+		if(result < 1) {
+			throw new AssetImgException("에셋 스크린샷 등록 실패");
+		}
+	}
+
+	@Override
+	public void update(AssetImg assetImg) throws AssetImgException {
+		int result = sqlSessionTemplate.update("AssetImg.update", assetImg);
+		if(result < 1) {
+			throw new AssetImgException("에셋 스크린샷 수정 실패");
+		}
+	}
+
+	@Override
+	public void delete(long asset_img_id) throws AssetImgException {
+		int result = sqlSessionTemplate.delete("AssetImg.delete", asset_img_id);
+		if(result < 1) {
+			throw new AssetImgException("에셋 스크린샷 삭제 실패");
+		}
+	}
+
+	@Override
+	public void deleteByAssetId(long asset_id) {
+		int result = sqlSessionTemplate.delete("AssetImg.deleteByAssetId", asset_id);
+		if(result < 1) {
+			throw new AssetImgException("에셋 스크린샷 다건 삭제 실패");
+		}
+	}
+	
+	
+
+}

--- a/HotSource/src/main/java/hotsource/model/cart/CartDAO.java
+++ b/HotSource/src/main/java/hotsource/model/cart/CartDAO.java
@@ -1,0 +1,19 @@
+package hotsource.model.cart;
+
+import java.util.List;
+
+import hotsource.domain.Cart;
+
+public interface CartDAO {
+	
+	public void insert(Cart cart);
+	
+	public List selectAll();
+	public Cart select(long cart_id);
+	public List selectByUserId(long user_id);
+	
+	public void delete(long cart_id);
+	public void deleteByCartIds(List<Long> cart_ids);
+	
+
+}

--- a/HotSource/src/main/java/hotsource/model/cart/CartService.java
+++ b/HotSource/src/main/java/hotsource/model/cart/CartService.java
@@ -1,0 +1,27 @@
+package hotsource.model.cart;
+
+import java.util.List;
+
+import hotsource.domain.Cart;
+
+public interface CartService {
+//	
+//	public List selectAll();
+//	public Cart select(int cart_id);
+	
+	// 특정 유저의 장바구니 목록 가져오기
+	public List getCartList(long user_id);
+	
+//	// 에셋 하나 장바구니에 담기  
+//	public void addToCart(Cart cart);
+//	
+//	// 비로그인 상태에서 에셋 담은 후 로그인할 시 유저의 기존 장바구니에 합치기 
+//	public void addAllToCart(List<Cart> carts);
+//	
+	// 한 건 삭제 
+	public void delete(long cart_id);
+	
+	//다 건 삭제
+	public void deleteSelected(List<Long> cart_ids);
+	
+}

--- a/HotSource/src/main/java/hotsource/model/cart/CartServiceImpl.java
+++ b/HotSource/src/main/java/hotsource/model/cart/CartServiceImpl.java
@@ -1,0 +1,37 @@
+package hotsource.model.cart;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import hotsource.exception.CartException;
+
+@Service
+public class CartServiceImpl implements CartService{
+
+	@Autowired
+	private CartDAO cartDAO;
+	
+	@Override
+	public List getCartList(long user_id) {
+		return cartDAO.selectByUserId(user_id);
+	}
+
+	@Override
+	@Transactional
+	public void delete(long cart_id) throws CartException{
+		cartDAO.delete(cart_id);
+	}
+
+	@Override
+	@Transactional
+	public void deleteSelected(List<Long> cart_ids) throws CartException{
+		if(cart_ids.size() < 1) {
+			throw new CartException("선택 항목이 없습니다.");
+		}
+		cartDAO.deleteByCartIds(cart_ids);
+	}
+		
+}

--- a/HotSource/src/main/java/hotsource/model/cart/MybatisCartDAO.java
+++ b/HotSource/src/main/java/hotsource/model/cart/MybatisCartDAO.java
@@ -1,0 +1,57 @@
+package hotsource.model.cart;
+
+import java.util.List;
+
+import org.mybatis.spring.SqlSessionTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+import hotsource.domain.Cart;
+import hotsource.exception.CartException;
+
+@Repository
+public class MybatisCartDAO implements CartDAO{
+	
+	@Autowired
+	private SqlSessionTemplate sqlSessionTemplate;
+
+	@Override
+	public void insert(Cart cart) throws CartException{
+		int result = sqlSessionTemplate.insert("Cart.insert", cart); 
+		if(result < 1) {
+			throw new CartException("장바구니 에셋 담기 실패");
+		}
+	}
+
+	@Override
+	public List selectAll() {
+		return sqlSessionTemplate.selectList("Cart.selectAll");
+	}
+
+	@Override
+	public Cart select(long cart_id) {
+		return sqlSessionTemplate.selectOne("Cart.select", cart_id);
+	}
+
+	@Override
+	public List selectByUserId(long user_id) {
+		return sqlSessionTemplate.selectList("Cart.selectByUserId", user_id);
+	}
+
+	@Override
+	public void delete(long cart_id) throws CartException{
+		int result = sqlSessionTemplate.delete("Cart.delete", cart_id);
+		if(result < 1) {
+			throw new CartException("장바구니 에셋 한 건 삭제 실패");
+		}
+	}
+
+	@Override
+	public void deleteByCartIds(List<Long> cart_ids) {
+		int result = sqlSessionTemplate.delete("Cart.deleteByCartIds", cart_ids);
+		if(result < cart_ids.size()) {
+			throw new CartException("장바구니 에셋 다 건 삭제 실패");
+		}
+	}
+
+}

--- a/HotSource/src/main/java/hotsource/model/sale/MybatisSaleDAO.java
+++ b/HotSource/src/main/java/hotsource/model/sale/MybatisSaleDAO.java
@@ -28,4 +28,9 @@ public class MybatisSaleDAO implements SaleDAO {
 	public Sale selectByAssetId(long asset_id) {
 		return sqlSessionTemplate.selectOne("Sale.selectByAssetId", asset_id);
 	}
+
+	@Override
+	public Sale selectValidByAssetId(long asset_id) {
+		return sqlSessionTemplate.selectOne("Sale.selectValidByAssetId", asset_id);
+	}
 }

--- a/HotSource/src/main/java/hotsource/model/sale/SaleDAO.java
+++ b/HotSource/src/main/java/hotsource/model/sale/SaleDAO.java
@@ -8,4 +8,5 @@ public interface SaleDAO {
 	public List selectAll();
 	public Sale select(long sale_id);
 	public Sale selectByAssetId(long asset_id);
+	public Sale selectValidByAssetId(long asset_id);
 }

--- a/HotSource/src/main/java/hotsource/model/sale/SaleService.java
+++ b/HotSource/src/main/java/hotsource/model/sale/SaleService.java
@@ -8,4 +8,5 @@ public interface SaleService {
 	public List selectAll();
 	public Sale select(long sale_id);
 	public Sale selectByAssetId(long asset_id);
+	public Sale selectValidByAssetId(long asset_id);
 }

--- a/HotSource/src/main/java/hotsource/model/sale/SaleServiceImpl.java
+++ b/HotSource/src/main/java/hotsource/model/sale/SaleServiceImpl.java
@@ -27,4 +27,9 @@ public class SaleServiceImpl implements SaleService {
 	public Sale selectByAssetId(long asset_id) {
 		return saleDAO.selectByAssetId(asset_id);
 	}
+
+	@Override
+	public Sale selectValidByAssetId(long asset_id) {
+		return saleDAO.selectByAssetId(asset_id);
+	}
 }

--- a/HotSource/src/main/java/hotsource/mybatis/AssetImgMapper.xml
+++ b/HotSource/src/main/java/hotsource/mybatis/AssetImgMapper.xml
@@ -33,6 +33,14 @@
         FROM asset_img
         WHERE asset_img_id = #{asset_img_id}
     </select>
+    
+    <!-- 썸네일 조회 -->
+    <select id="selectThumbnailByAssetId" parameterType="long" resultType="AssetImg">
+    	select <include refid="columns"/> 
+    	from asset_img 
+    	where asset_id = #{asset_id} 
+    	and is_thumb = true;
+    </select>
 
     <!-- 3. 등록 -->
     <insert id="insert" parameterType="AssetImg">

--- a/HotSource/src/main/java/hotsource/mybatis/AssetMapper.xml
+++ b/HotSource/src/main/java/hotsource/mybatis/AssetMapper.xml
@@ -5,7 +5,7 @@
 <mapper namespace="Asset">
 
     <sql id="columns">
-        asset_id, subcategory_id, seller_id, title, price, summary,
+        asset_id, subcategory_id, seller_id, title, price, summary, 
         description, youtube_url, create_date, view_count
     </sql>
 
@@ -19,15 +19,15 @@
         <result property="youtube_url" column="youtube_url"/>
         <result property="create_date" column="create_date"/>
         <result property="view_count" column="view_count"/>
-
+ 
         <!-- 외래키는 객체 대신 ID만 담김 -->
-        <association property="seller" javaType="Seller">
-            <id property="seller_id" column="seller_id"/>
-        </association>
-
+        <association column="seller_id" property="seller" javaType="Seller" select="Seller.select"/>
+           
         <association property="subCategory" javaType="SubCategory">
             <id property="subcategory_id" column="subcategory_id"/>
         </association>
+        
+        <association column="sale_id" property="sale" javaType="Sale" select="Sale.selectValidByAssetId"></association>
         
         <collection property="reviewList" column="asset_id" javaType="java.util.List" ofType="Review" select="Review.selectByAssetId"/>
     </resultMap>
@@ -52,6 +52,7 @@
     <select id="selectBySellerId" parameterType="long" resultMap="AssetResultMap">
 		SELECT <include refid="columns"/> FROM asset WHERE seller_id = #{seller_id}
 	</select>
+
 
     <!-- 등록 -->
     <insert id="regist" parameterType="Asset">

--- a/HotSource/src/main/java/hotsource/mybatis/CartMapper.xml
+++ b/HotSource/src/main/java/hotsource/mybatis/CartMapper.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="Cart">
-	
+	<insert id="insert" parameterType="cart">
+            insert into cart(asset_id, user_id) values(#{asset.asset_id}, #{user.user_id})
+    </insert>
 	<sql id="columns">
 		cart_id, create_date, asset_id, user_id
 	</sql>
@@ -22,7 +24,20 @@
 	</select>
 	
 	<select id="selectByUserId" resultMap="joinMap" parameterType="long">
-		SELECT <include refid="columns"/> FROM cart WHERE user_id=#{user_id}
+		SELECT <include refid="columns"/> FROM cart WHERE user_id=#{user_id} ORDER BY create_date DESC
 	</select>
 	
+	<!-- 단건 삭제 -->
+    <delete id="delete" parameterType="long">
+            delete from cart where cart_id = #{cart_id}
+    </delete>
+    
+    <!-- 다건 삭제 -->
+    <delete id="deleteByCartIds" parameterType="list">
+            delete from cart where cart_id in
+            <foreach item="cart_id" collection="list" open="(" separator="," close=")">
+                    #{cart_id}
+            </foreach>
+    </delete>
+    
 </mapper>

--- a/HotSource/src/main/java/hotsource/mybatis/SaleMapper.xml
+++ b/HotSource/src/main/java/hotsource/mybatis/SaleMapper.xml
@@ -3,17 +3,15 @@
 <mapper namespace="Sale">
 	
 	<sql id="columns">
-		sale_id, sale_type, sale_value, start_date, end_date, create_date, asset_id
+		sale_id, sale_value, start_date, end_date, create_date, asset_id
 	</sql>
 	
 	<resultMap 			type="Sale" 					id="joinMap">
 		<id 					column="sale_id" 			property="sale_id"/>
-		<result 			column="sale_type" 		property="sale_type"/>
 		<result 			column="sale_value" 		property="sale_value"/>
 		<result 			column="start_date" 		property="start_date"/>
 		<result 			column="end_date" 		property="end_date"/>
 		<result 			column="create_date" 	property="create_date"/>
-		<association 	column="asset_id" 		property="asset" 			javaType="Asset" 		select="Asset.select"/>
 	</resultMap>
 	
 	<select id="selectAll" resultMap="joinMap">
@@ -27,5 +25,12 @@
 	<select id="selectByAssetId" resultMap="joinMap" parameterType="long">
 		SELECT <include refid="columns"/> FROM sale WHERE asset_id=#{asset_id}
 	</select>
+	
+	<!-- 현재 날짜 기준으로 유효한 할인 정보 조회 -->
+	<select id="selectValidByAssetId" resultMap="joinMap" parameterType="long">
+		SELECT <include refid="columns"/> FROM sale WHERE asset_id=#{asset_id}  
+		AND CURDATE() BETWEEN start_date AND end_date
+	</select>
+	
 	
 </mapper>

--- a/HotSource/src/main/java/hotsource/mybatis/mybatis-config.xml
+++ b/HotSource/src/main/java/hotsource/mybatis/mybatis-config.xml
@@ -51,9 +51,7 @@
 		<mapper resource="hotsource/mybatis/AssetListMapper.xml" />
 		<mapper resource="hotsource/mybatis/AssetMapper.xml" />
 		<mapper resource="hotsource/mybatis/AssetViewMapper.xml" />
-		
-		<!-- <mapper resource="hotsource/mybatis/CartMapper.xml" /> -->
-		
+		<mapper resource="hotsource/mybatis/CartMapper.xml" />
 		<mapper resource="hotsource/mybatis/KeywordMapper.xml" />
 		<mapper resource="hotsource/mybatis/NoticeCommentMapper.xml" />
 		<mapper resource="hotsource/mybatis/NoticeLikeMapper.xml" />

--- a/HotSource/src/main/java/hotsource/spring/config/RootConfig.java
+++ b/HotSource/src/main/java/hotsource/spring/config/RootConfig.java
@@ -14,6 +14,7 @@ import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.jndi.JndiTemplate;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.springframework.web.multipart.commons.CommonsMultipartResolver;
 
 /*
  * 애플리케이션 Scope 수준에서 관리될 빈즈들의 대한 설정파일
@@ -49,6 +50,13 @@ public class RootConfig{
 		@Bean
 		public SqlSessionTemplate sqlSessionTemplate() throws Exception {
 			return new SqlSessionTemplate(sqlSessionFactory());
+		}
+		
+		@Bean
+		public CommonsMultipartResolver multipartResolver() {
+			CommonsMultipartResolver resolver = new CommonsMultipartResolver();
+			resolver.setMaxUploadSize(10*1024*1024); // 10M
+			return resolver;
 		}
 		
 }

--- a/HotSource/src/main/java/hotsource/util/LoginBypassFilter.java
+++ b/HotSource/src/main/java/hotsource/util/LoginBypassFilter.java
@@ -1,0 +1,44 @@
+package hotsource.util;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+import hotsource.domain.User;
+
+public class LoginBypassFilter implements Filter{
+
+	@Override
+	public void doFilter(ServletRequest req, ServletResponse resp, FilterChain chain)
+			throws IOException, ServletException {
+
+		HttpServletRequest request = (HttpServletRequest)req;
+		HttpSession session = request.getSession();
+		
+		if(session.getAttribute("user") == null) {
+			User dummy= new User();
+			dummy.setUser_id(1);
+			dummy.setUser_name("테스트유저");
+			
+			session.setAttribute("user", dummy);
+		}
+		chain.doFilter(req, resp);
+		
+	}
+
+	@Override
+	public void init(FilterConfig filterConfig) throws ServletException {
+	}
+
+	@Override
+	public void destroy() {
+	}
+
+}

--- a/HotSource/src/main/webapp/WEB-INF/views/main/cart/list.jsp
+++ b/HotSource/src/main/webapp/WEB-INF/views/main/cart/list.jsp
@@ -1,0 +1,190 @@
+<%@page import="hotsource.domain.AssetImg"%>
+   <%@page import="hotsource.domain.Cart"%>
+<%@page import="java.util.List"%>
+<%@ page contentType="text/html; charset=UTF-8"%>
+<%
+	List<Cart> cartList = (List)request.getAttribute("cartList");
+	List<Integer> discountList = (List)request.getAttribute("discountList");
+	List<AssetImg> thumbnailList = (List)request.getAttribute("thumbnailList");
+%>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>쇼핑몰</title>
+
+	<!-- link Font, CSS -->
+    <%@ include file="../inc/head_link.jsp"%>
+</head>
+
+<body>
+    <!-- Page Preloder -->
+    <div id="preloder">
+        <div class="loader"></div>
+    </div>
+	<!-- 헤더 및 배너 영역 시작 -->
+	<div class="hero_area">
+
+		<!-- 헤더 영역 시작 -->
+		<%@ include file="../inc/header_search.jsp" %>
+		
+		<!-- 헤더 영역 끝-->
+
+	</div>
+	<!-- 헤더 및 배너 영역 끝 -->
+
+    <!-- Breadcrumb Begin -->
+    <div class="breadcrumb-option">
+        <div class="container">
+            <div class="row">
+                <div class="col-lg-12">
+                    <div class="breadcrumb__links">
+                        <a href="./index.html"><i class="fa fa-home"></i> Home</a>
+                        <span>Shopping cart</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <!-- Breadcrumb End -->
+
+     <!-- Shop Cart Section Begin --> 
+    <section class="shop-cart spad">
+        <div class="container">
+            <div class="row">
+            	<!-- ✅ 왼쪽: 장바구니 목록 (8칸) -->
+                <div class="col-lg-8">
+                	<div class="shop__cart__table">
+                    	<div class="cart-header">
+                    		<input type="checkbox" class="cart-header-check" checked>
+  							<h3>장바구니에 <span id="selectedCount"><%=cartList.size() %></span>개 상품이 있습니다</h3>
+						</div>
+                        <table>
+                            <tbody>
+                            <%for(int i = 0; i < cartList.size(); i++){ %>
+                            <%Cart cart = cartList.get(i); %>
+                           
+                          
+                            	<tr>
+                                    <td class="cart__product__item">
+									    <div class="cart-item-wrapper">
+									  		<!-- 장바구니 아이템의 기본키 값  -->
+									  		<input type="hidden" class="cart-id" value="<%=cart.getCart_id()%>">
+									    	<!-- 체크박스 -->
+									    	<input type="checkbox" class="cart-check" checked>
+									
+									    	<!-- 이미지 -->
+									    	<img id="thumb_<%=cart.getAsset().getAsset_id() %>" src=""  style="width: 100px; height: 100px;" alt="">
+									
+									    	<!-- 텍스트 영역 --> 
+									    	<div class="cart__product__item__content">
+										      	<div class="author-name"><%=cart.getAsset().getSeller().getSeller_name() %></div>
+										      	<div class="cart__product__item__title">
+										        <h6><%= cart.getAsset().getTitle() %></h6>
+										 		</div>
+										      
+										     	<!-- 삭제, 찜 버튼 영역 -->
+										      	<div class="button-group">
+										        	<button class="icon-button bt_delete" type="button">
+										          		<i class="bi bi-trash"></i> delete
+										       		</button>
+										        	<button class="icon-button bt_jjim" type="button" >
+										         	<i class="bi bi-heart"></i> jjim
+										        	</button>
+										      	</div>
+									    	</div>
+									  </div>
+									</td>
+                                    <td class="cart__price">
+                                    <% 
+                                    int originalPrice = cart.getAsset().getPrice(); 
+                                    int discountPrice = discountList.get(i); 
+                                    boolean isDiscounted = discountPrice > 0 && discountPrice < originalPrice;
+                                    %>
+	                                    <span class="original-price" style="<%= isDiscounted ? "" : "color: black; text-decoration: none;" %>">
+									      $<%= originalPrice %>
+									    </span>
+									    <span class="sale-price" style="<%= isDiscounted ? "" : "display: none;" %>">
+									      $<%= discountPrice %>
+									    </span>
+                                    </td>
+                                </tr>
+                                <%} %>
+                            </tbody>
+                        </table>
+                        
+                        <div class="cart__btn mt-3" id="bt_delete_selected">
+                        	<a href="#">선택 에셋 장바구니에서 제외</a>
+                    	</div>
+                    </div>
+                </div>
+                
+                <!-- ✅ 오른쪽: 결제 영역 (4칸) -->     
+                <div class="col-lg-4">
+	                <div class="cart__total__procced">
+	                    <h6>Cart total</h6>
+	                    <ul>
+	                        <li>Subtotal <span></span></li>
+	                        <li>Total <span></span></li>
+	                    </ul>
+	                    <a href="#" class="primary-btn">Proceed to checkout</a>
+	                </div>
+            	</div>
+			</div>
+		</div>
+    </section>
+    <!-- Shop Cart Section End -->
+    
+    <!-- 푸터 영역 시작 -->
+	<%@ include file="../inc/footer.jsp" %>
+	<!-- 푸터 영역 끝 -->
+	
+<!-- Js Plugins -->
+<%@ include file="../inc/footer_link.jsp" %>
+    
+<script type="text/javascript">
+//비동기 방식으로, 서버의 이미지를 다운로드 받기 
+	function getImgList(asset_id, filename){
+		console.log("넘겨받은 파일명은 ", filename);
+		$.ajax({
+			url:"/data/asset_img/" + asset_id + "/" + filename, 
+			type:"GET",
+			//서버로부터 가져온 이미지 정보는 img src로 표현되려면, 
+			//1) 서버로 부터 가져온 정보를 Blob 형태로 가져와서
+			//2) 웹브라우저 지원 객체인 File 로 변환 
+			//3) 이 파일을 읽어들인 후 e.target.result 형태로 img src에 대입
+			//XMLHttpRequest 객체를 이용해야 함
+			xhr: function(){
+				const xhr = new XMLHttpRequest();
+				xhr.responseType="blob"; 
+				return xhr;
+			},
+			success:function(result, status, xhr){
+				console.log("서버로부터 받은 바이너리 정보는 ",result);
+				const file = new File([result], filename, {type: result.type});
+				
+				const reader = new FileReader();
+				reader.onload=function(e){
+					
+					const imgTag = document.querySelector("#thumb_" + asset_id);
+					if (imgTag) {
+						imgTag.src = e.target.result;
+						console.log(imgTag.src);
+					}
+				}
+				reader.readAsDataURL(file);//대상 파일 읽기 
+			}
+		});
+	}
+	<% for (int i = 0; i < cartList.size(); i++) {
+		Cart cart = cartList.get(i);
+		AssetImg thumb = thumbnailList.get(i); %>
+		getImgList(<%= cart.getAsset().getAsset_id() %>, "<%= thumb.getAsset_img_url() %>");
+	<% } %>
+</script>
+    
+</body>
+
+</html>

--- a/HotSource/src/main/webapp/WEB-INF/web.xml
+++ b/HotSource/src/main/webapp/WEB-INF/web.xml
@@ -29,6 +29,16 @@
 		<filter-name>encodingFilter</filter-name>
 		<url-pattern>/*</url-pattern>		
 	</filter-mapping>
+	
+	<!-- 임시 로그인  -->
+	<!-- <filter>
+		<filter-name>loginBypassFilter</filter-name>
+		<filter-class>hotsource.util.LoginBypassFilter</filter-class>
+	</filter>
+	<filter-mapping>
+		<filter-name>loginBypassFilter</filter-name>
+		<url-pattern>/*</url-pattern>		
+	</filter-mapping> -->
 
 	<!-- 모든 요청은 1차적으로 하나의 서블릿으로 처리해야 하므로, 하나의 진입점이 되는 서블릿을 정의 -->
 

--- a/HotSource/src/main/webapp/static/css/cart.css
+++ b/HotSource/src/main/webapp/static/css/cart.css
@@ -67,3 +67,19 @@
   width: 20px;
   height: 20px;
 }
+
+.cart__price {
+  text-align: right;
+  padding-right: 30px !important;  /* ← 여기 조절 */
+}
+
+.original-price {
+    color: gray;
+    text-decoration: line-through;
+    margin-right: 0.5rem;
+}
+
+.sale-price {
+    color: red;
+    font-weight: bold;
+}

--- a/HotSource/src/main/webapp/static/js/cart.js
+++ b/HotSource/src/main/webapp/static/js/cart.js
@@ -3,6 +3,31 @@ function countChecked(){
 	let count = $(".cart-check:checked").length;
 	$("#selectedCount").text(count);
 }
+
+function calculateTotals(){
+	let total = 0;
+	let subtotal = 0;
+	
+	$(".cart-check:checked").each(function(){
+		//$ Jquery 객체임을 표시 (jquery 객체는 js dom api와 jquery 특화 메서드를 모두 사용 가능 )
+		$row = $(this).closest("tr");
+		
+		//정가 
+		origin = parseInt($row.find(".original-price").text().replace(/[$,]/g, "").trim());
+		subtotal += origin;
+		
+		//할인 적용된 최종 가격 
+		total += (
+				$row.find(".sale-price").is(":visible") 
+				? parseInt($row.find(".sale-price").text().replace(/[$,]/g, "").trim())
+				: origin
+			);
+	});
+	
+	 $(".cart__total__procced li:contains('Subtotal') span").text(subtotal);
+	 $(".cart__total__procced li:contains('Total') span").text(total);
+}
+
 function removeFromCart(bt){
 	const cartId = $(bt).closest(".cart-item-wrapper").find(".cart-id").val();
 	console.log(cartId);
@@ -51,6 +76,9 @@ function removeSelectedFromCart(){
 }
 
 $(()=>{
+	
+	calculateTotals();
+
 	//전체 체크박스 클릭시 전체 선택/해제  
 	$(".cart-header-check").change(function(){
 		const isChecked = $(this).is(":checked");
@@ -66,6 +94,7 @@ $(()=>{
 		// 개별 체크박스가 변경될 때 → 전체 선택 상태도 맞춰주기
 		$(".cart-header-check").prop("checked", total === checked);
 		countChecked();
+		calculateTotals();
 	});
 	
 	//한 건 삭제 이벤트
@@ -84,3 +113,6 @@ $(()=>{
 	});
 	
 });
+
+
+


### PR DESCRIPTION
기능
- 장바구니 목록 조회
- 장바구니 항목 삭제

아직 장바구니 이동 버튼에 페이지 연결을 못해서 조회하려면 로그인 후 /main/cart로 접근하시면 돼요

도메인 변경 
Asset : Sale 객체 보유하도록 변경 (현재 유효한 세일 정보)
Sale : List<Asset> assetList 삭제 (Asset에서 Sale객체를 추가하니까 mybatis에서 무한루프가 발생했고, Sale을 통해 asset을 접근하는 일이 없을 거 같아서 삭제)

web.xml 
테스트용 임시 로그인 필터 추가
서버 껐다 켜면 매번 로그인해야해서 테스트하기 번거로우니 항상 로그인 상태인 걸로 설정하는 기능입니다.

util.LoginByPassFilter.java
여기서 원하는 로그인 유저 id 설정하시면 항상 해당 사용자로 로그인한 상태로 테스트할 수 있어요! 

